### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ Interface for using [cubed](https://github.com/cubed-dev/cubed) with [xarray](ht
 
 ## Requirements
 
-- Cubed version >=0.14.2
-- Xarray version >=2024.02.0
+- Cubed version >=0.17.0
+- Xarray version >=2024.09.0
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,16 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
-    "numpy >= 1.17.1",
-    "xarray >= 2024.02.0",
-    "cubed >= 0.14.2",
+    "numpy >= 1.22",
+    "xarray >= 2024.09.0",
+    "cubed >= 0.17.0",
 ]
 
 


### PR DESCRIPTION
Both Cubed and Xarray now require Python >= 3.10.